### PR TITLE
feat: support public sharing of notes by tag_id and note_id

### DIFF
--- a/annotations/serializers.py
+++ b/annotations/serializers.py
@@ -114,6 +114,7 @@ class NoteSerializer(serializers.ModelSerializer):
     user = serializers.HiddenField(
         default=CurrentAuthenticatedUserDefault()
     )
+    is_owner = serializers.SerializerMethodField(read_only=True)
     verse_references = NoteVerseReferenceSerializer(
         many=True,
         write_only=True,
@@ -123,6 +124,18 @@ class NoteSerializer(serializers.ModelSerializer):
             "to link to the note."
         )
     )
+
+    def get_is_owner(self, obj):
+        """True when the requesting user owns this note. Used by
+        clients to gate edit/delete controls on shared notes without
+        exposing the owner's username.
+        """
+        request = self.context.get('request')
+        return bool(
+            request
+            and request.user.is_authenticated
+            and obj.user_id == request.user.id
+        )
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -145,7 +158,7 @@ class NoteSerializer(serializers.ModelSerializer):
         model = Note
         fields = [
             'id', 'user', 'note_text', 'public', 'created_at', 'updated_at',
-            'tag', 'verse_references'
+            'tag', 'verse_references', 'is_owner'
         ]
 
     def create(self, validated_data):

--- a/annotations/tests.py
+++ b/annotations/tests.py
@@ -232,6 +232,23 @@ class PublicNoteSharingTests(TestCase):
         resp = self.anon.get(url)
         self.assertEqual(resp.status_code, status.HTTP_404_NOT_FOUND)
 
+    def test_owner_can_retrieve_own_private_only_tag(self):
+        private_only = Tag.objects.create(
+            user=self.owner, name='PrivateOnly'
+        )
+        Note.objects.create(
+            user=self.owner, tag=private_only,
+            note_text='private', public=False,
+        )
+        url = reverse('tag-detail', args=[private_only.id])
+        resp = self.owner_client.get(url)
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        self.assertEqual(resp.data['name'], 'PrivateOnly')
+
+        # But another authenticated user still cannot retrieve it.
+        other_resp = self.other_client.get(url)
+        self.assertEqual(other_resp.status_code, status.HTTP_404_NOT_FOUND)
+
     def test_anonymous_tag_list_requires_auth(self):
         url = reverse('tag-list')
         resp = self.anon.get(url)

--- a/annotations/tests.py
+++ b/annotations/tests.py
@@ -1,8 +1,12 @@
 import datetime
 from django.test import TestCase
 from django.contrib.auth import get_user_model
-from rest_framework.test import APIRequestFactory
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.authtoken.models import Token
+from rest_framework.test import APIRequestFactory, APIClient
 from rest_framework.request import Request
+from annotations.models import Note, Tag
 from annotations.serializers import TagSerializer, NoteSerializer
 from bible.models import Verse
 
@@ -82,3 +86,153 @@ class SerializerTestCase(TestCase):
         self.assertEqual(verse.book, 'John')
         self.assertEqual(verse.chapter, 3)
         self.assertEqual(verse.verse, 16)
+
+
+class PublicNoteSharingTests(TestCase):
+    """End-to-end tests for the public note sharing flow.
+
+    Covers Bible-Research/bible-research#9:
+    - Anonymous GET of notes by tag_id returns only public notes.
+    - Anonymous GET of a public note by id succeeds; private 404s.
+    - Authenticated user sees own private notes + others' public notes
+      when filtering by tag_id, never others' private notes.
+    - Write actions require authentication.
+    - is_owner is true only for the note's owner.
+    - Tag retrieve is anonymously accessible for tags with public notes.
+    """
+
+    def setUp(self):
+        User = get_user_model()
+        self.owner = User.objects.create_user(
+            username='owner', password='pw-owner'
+        )
+        self.other = User.objects.create_user(
+            username='other', password='pw-other'
+        )
+
+        self.owner_token = Token.objects.create(user=self.owner).key
+        self.other_token = Token.objects.create(user=self.other).key
+
+        self.owner_tag = Tag.objects.create(user=self.owner, name='OwnerTag')
+        self.other_tag = Tag.objects.create(user=self.other, name='OtherTag')
+
+        self.owner_public = Note.objects.create(
+            user=self.owner, tag=self.owner_tag,
+            note_text='owner public note', public=True,
+        )
+        self.owner_private = Note.objects.create(
+            user=self.owner, tag=self.owner_tag,
+            note_text='owner private note', public=False,
+        )
+        self.other_public = Note.objects.create(
+            user=self.other, tag=self.other_tag,
+            note_text='other public note', public=True,
+        )
+        self.other_private = Note.objects.create(
+            user=self.other, tag=self.other_tag,
+            note_text='other private note', public=False,
+        )
+
+        self.anon = APIClient()
+        self.owner_client = APIClient()
+        self.owner_client.credentials(
+            HTTP_AUTHORIZATION=f'Token {self.owner_token}'
+        )
+        self.other_client = APIClient()
+        self.other_client.credentials(
+            HTTP_AUTHORIZATION=f'Token {self.other_token}'
+        )
+
+    def _note_ids(self, response):
+        return {item['id'] for item in response.data}
+
+    def test_anonymous_list_by_tag_returns_only_public(self):
+        url = reverse('note-list')
+        resp = self.anon.get(url, {'tag_id': self.other_tag.id})
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        ids = self._note_ids(resp)
+        self.assertIn(self.other_public.id, ids)
+        self.assertNotIn(self.other_private.id, ids)
+        self.assertNotIn(self.owner_public.id, ids)
+        self.assertNotIn(self.owner_private.id, ids)
+
+    def test_anonymous_retrieve_public_note_ok(self):
+        url = reverse('note-detail', args=[self.owner_public.id])
+        resp = self.anon.get(url)
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        self.assertEqual(resp.data['id'], self.owner_public.id)
+        self.assertFalse(resp.data['is_owner'])
+
+    def test_anonymous_retrieve_private_note_404(self):
+        url = reverse('note-detail', args=[self.owner_private.id])
+        resp = self.anon.get(url)
+        self.assertEqual(resp.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_authenticated_list_by_others_tag_mixes_own_and_public(self):
+        cross_tag_private = Note.objects.create(
+            user=self.owner, tag=self.other_tag,
+            note_text='cross-tag private', public=False,
+        )
+        url = reverse('note-list')
+        resp = self.owner_client.get(url, {'tag_id': self.other_tag.id})
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        ids = self._note_ids(resp)
+        self.assertIn(self.other_public.id, ids)
+        self.assertIn(cross_tag_private.id, ids)
+        self.assertNotIn(self.other_private.id, ids)
+
+    def test_authenticated_plain_list_returns_only_own(self):
+        url = reverse('note-list')
+        resp = self.owner_client.get(url)
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        ids = self._note_ids(resp)
+        self.assertEqual(ids, {self.owner_public.id, self.owner_private.id})
+
+    def test_is_owner_flag(self):
+        url = reverse('note-detail', args=[self.owner_public.id])
+        owner_resp = self.owner_client.get(url)
+        other_resp = self.other_client.get(url)
+        self.assertTrue(owner_resp.data['is_owner'])
+        self.assertFalse(other_resp.data['is_owner'])
+
+    def test_anonymous_cannot_write(self):
+        url = reverse('note-list')
+        payload = {
+            'note_text': 'nope', 'public': True, 'tag': self.owner_tag.id,
+        }
+        self.assertEqual(
+            self.anon.post(url, payload, format='json').status_code,
+            status.HTTP_401_UNAUTHORIZED,
+        )
+        detail = reverse('note-detail', args=[self.owner_public.id])
+        self.assertEqual(
+            self.anon.patch(detail, {'note_text': 'x'}).status_code,
+            status.HTTP_401_UNAUTHORIZED,
+        )
+        self.assertEqual(
+            self.anon.delete(detail).status_code,
+            status.HTTP_401_UNAUTHORIZED,
+        )
+
+    def test_tag_retrieve_public_for_tag_with_public_note(self):
+        url = reverse('tag-detail', args=[self.other_tag.id])
+        resp = self.anon.get(url)
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        self.assertEqual(resp.data['name'], 'OtherTag')
+
+    def test_tag_retrieve_404_when_no_public_notes(self):
+        private_only = Tag.objects.create(
+            user=self.owner, name='PrivateOnly'
+        )
+        Note.objects.create(
+            user=self.owner, tag=private_only,
+            note_text='private', public=False,
+        )
+        url = reverse('tag-detail', args=[private_only.id])
+        resp = self.anon.get(url)
+        self.assertEqual(resp.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_anonymous_tag_list_requires_auth(self):
+        url = reverse('tag-list')
+        resp = self.anon.get(url)
+        self.assertEqual(resp.status_code, status.HTTP_401_UNAUTHORIZED)

--- a/annotations/views.py
+++ b/annotations/views.py
@@ -1,6 +1,6 @@
 import logging
 
-from rest_framework import viewsets
+from rest_framework import permissions, viewsets
 from django.contrib.auth import get_user_model
 from django.db import models
 
@@ -18,9 +18,16 @@ class TagViewSet(viewsets.ModelViewSet):
     """
     API endpoint that allows tags to be created, viewed, updated, or deleted.
 
-    Users can only see and manage their own tags.
+    - `retrieve` is public for any tag that has at least one public note,
+      so share pages can resolve tag names.
+    - `list` and all write actions are restricted to the owning user.
     """
     serializer_class = TagSerializer
+
+    def get_permissions(self):
+        if self.action == 'retrieve':
+            return [permissions.AllowAny()]
+        return [permissions.IsAuthenticated()]
 
     def get_queryset(self):
         """
@@ -134,9 +141,17 @@ class NoteViewSet(viewsets.ModelViewSet):
     Additional filtering:
     - GET /api/v1/notes/?tag_id={tag_id} - List notes filtered by tag ID
     - GET /api/v1/notes/?public=true - List both public and private notes
+
+    Permissions:
+    - `list` and `retrieve` are public (filtered to public-only for anonymous).
+    - All write actions require authentication.
     """
     serializer_class = NoteSerializer
-    # permission_classes = [permissions.IsAuthenticated]
+
+    def get_permissions(self):
+        if self.action in ('list', 'retrieve'):
+            return [permissions.AllowAny()]
+        return [permissions.IsAuthenticated()]
 
     def perform_create(self, serializer):
         """

--- a/annotations/views.py
+++ b/annotations/views.py
@@ -242,91 +242,50 @@ class NoteViewSet(viewsets.ModelViewSet):
 
     def get_queryset(self):
         """
-        Returns the queryset of notes that the current user
-        has access to.
-        - Authenticated users see their own private notes
-          by default
-        - Unauthenticated users see only public notes
+        Returns the queryset of notes the current caller may see.
 
-        Available query parameters:
-        - GET /api/v1/notes/ - List user's own notes
-        - GET /api/v1/notes/?public=true - List public notes
-          and user's notes
-        - GET /api/v1/notes/<pk>/ - Retrieve a specific note
-          by its ID
-        - GET /api/v1/notes/?tag_id=<tag_id> - Filter by
-          tag ID
-
-        Special cases:
-        - When requesting a specific note by ID:
-          Users see the note if it's public or their own
-        - When filtering by tag_id:
-          Users see all public notes with that tag and
-          their own notes
+        Rules:
+        - Anonymous callers see notes where `public=True`, restricted by
+          `tag_id`/`pk` if given.
+        - Authenticated callers always see their own notes; when the
+          request is a share view (by `tag_id` or `pk`) or opts into
+          `?public=true`, they also see every other `public=True` note
+          matching the filter.
+        - Plain `GET /api/v1/notes/` only returns the caller's own notes
+          (empty for anonymous).
         """
         user = self.request.user
         note_pk = self.kwargs.get('pk', None)
         tag_id = self.request.query_params.get('tag_id', None)
+        public_param = self.request.query_params.get(
+            'public', ''
+        ).lower() == 'true'
+        is_share_view = bool(note_pk or tag_id)
 
         logger.info(
-            f"NoteViewSet.get_queryset called for user: "
-            f"{user.username if user.is_authenticated else 'Anonymous'} "
-            f"| note_pk: {note_pk} | tag_id: {tag_id}"
+            "NoteViewSet.get_queryset | user=%s | note_pk=%s | tag_id=%s"
+            " | public_param=%s | is_share_view=%s",
+            user.username if user.is_authenticated else 'Anonymous',
+            note_pk, tag_id, public_param, is_share_view,
         )
 
-        if note_pk or tag_id:
-            # If specific note or tag is requested,
-            # search it in public notes
-            public = True
-            logger.debug(
-                "Setting public=True due to note_pk "
-                "or tag_id filter"
-            )
-        else:
-            # Otherwise evaluate if user requested public notes
-            public_param = self.request.query_params.get(
-                'public',
-                ''
-            ).lower()
-            public = public_param == 'true'
-            logger.debug(
-                f"Public parameter: {public_param}, "
-                f"public={public}"
-            )
-
         if user.is_authenticated:
-            user_notes = models.Q(user=user)
-            if public:
-                queryset = Note.objects.filter(
-                    user_notes | models.Q(public=True)
-                )
-                logger.debug(
-                    f"Authenticated user {user.username}: "
-                    f"Fetching own notes + public notes"
-                )
+            own = models.Q(user=user)
+            if is_share_view or public_param:
+                queryset = Note.objects.filter(own | models.Q(public=True))
             else:
-                queryset = Note.objects.filter(user_notes)
-                logger.debug(
-                    f"Authenticated user {user.username}: "
-                    f"Fetching only own notes"
-                )
+                queryset = Note.objects.filter(own)
         else:
-            queryset = Note.objects.filter(public=public)
-            logger.debug(
-                "Unauthenticated user: "
-                "Fetching public notes only"
-            )
+            queryset = Note.objects.filter(public=True)
 
         if tag_id:
             queryset = queryset.filter(tag_id=tag_id)
-            logger.debug(f"Filtering by tag_id: {tag_id}")
-
         if note_pk:
             queryset = queryset.filter(id=note_pk)
-            logger.debug(f"Filtering by note_pk: {note_pk}")
 
         final_queryset = queryset.order_by('-created_at')
         logger.info(
-            f"Returning {final_queryset.count()} notes"
+            "NoteViewSet.get_queryset returning %d notes",
+            final_queryset.count(),
         )
         return final_queryset

--- a/annotations/views.py
+++ b/annotations/views.py
@@ -33,15 +33,23 @@ class TagViewSet(viewsets.ModelViewSet):
         """
         Returns the queryset of tags the caller may see.
 
-        - `retrieve`: any tag that has at least one public note. This
-          lets share pages resolve a tag's name without owning it.
+        - `retrieve`:
+            * authenticated: own tags ∪ tags with at least one public note
+              (so the owner can always resolve their own tags, even
+              private-only ones, and still follow shared links);
+            * anonymous: tags with at least one public note.
         - `list` (and writes, which require auth): the caller's own tags.
         - Anonymous callers get an empty list for `list`.
         """
         user = self.request.user
 
         if self.action == 'retrieve':
-            return Tag.objects.filter(notes__public=True).distinct()
+            public_qs = Tag.objects.filter(notes__public=True)
+            if user.is_authenticated:
+                return (
+                    public_qs | Tag.objects.filter(user=user)
+                ).distinct()
+            return public_qs.distinct()
 
         if user.is_authenticated:
             return Tag.objects.filter(user=user).order_by('name')

--- a/annotations/views.py
+++ b/annotations/views.py
@@ -31,45 +31,22 @@ class TagViewSet(viewsets.ModelViewSet):
 
     def get_queryset(self):
         """
-        Returns the queryset of tags that the current user
-        has access to.
-        Authenticated users see their own tags.
-        Unauthenticated users see the guest user's tags.
+        Returns the queryset of tags the caller may see.
+
+        - `retrieve`: any tag that has at least one public note. This
+          lets share pages resolve a tag's name without owning it.
+        - `list` (and writes, which require auth): the caller's own tags.
+        - Anonymous callers get an empty list for `list`.
         """
         user = self.request.user
-        logger.info(
-            f"TagViewSet.get_queryset called for user: "
-            f"{user.username if user.is_authenticated else 'Anonymous'}"
-        )
 
-        # For authenticated users, return their own tags
+        if self.action == 'retrieve':
+            return Tag.objects.filter(notes__public=True).distinct()
+
         if user.is_authenticated:
-            queryset = Tag.objects.filter(
-                user=user
-            ).order_by('name')
-            logger.debug(
-                f"Returning {queryset.count()} tags "
-                f"for user {user.username}"
-            )
-            return queryset
+            return Tag.objects.filter(user=user).order_by('name')
 
-        # For unauthenticated users, return guest user's tags
-        try:
-            guest_user = User.objects.get(username='guest')
-            queryset = Tag.objects.filter(
-                user=guest_user
-            ).order_by('name')
-            logger.debug(
-                f"Returning {queryset.count()} tags "
-                f"for guest user"
-            )
-            return queryset
-        except User.DoesNotExist:
-            logger.warning(
-                "Guest user does not exist, "
-                "returning empty queryset"
-            )
-            return Tag.objects.none()
+        return Tag.objects.none()
 
     def perform_create(self, serializer):
         """

--- a/bible_research/middleware.py
+++ b/bible_research/middleware.py
@@ -10,6 +10,15 @@ class DeviceAndCountryMiddleware:
     and country information from Cloudflare headers or IP address.
     """
 
+    # Paths that must remain truly anonymous when no credentials are sent.
+    # Auto-authentication would silently create phantom users and hide the
+    # real DRF permission result for shared public-read endpoints.
+    PUBLIC_READ_PREFIXES = (
+        '/api/v1/bible',
+        '/api/v1/notes',
+        '/api/v1/tags',
+    )
+
     def __init__(self, get_response):
         self.get_response = get_response
 
@@ -19,11 +28,18 @@ class DeviceAndCountryMiddleware:
         self.primary_language(request)
 
         path = request.path
-        auto_authentication = not request.user.is_authenticated \
-            or not (path.startswith('/admin')
-                    or path.startswith('/api/v1/bible'))
+        method = request.method
+        is_public_read = (
+            method in ('GET', 'HEAD', 'OPTIONS')
+            and any(path.startswith(p) for p in self.PUBLIC_READ_PREFIXES)
+        )
+        should_auto_authenticate = (
+            not request.user.is_authenticated
+            and not path.startswith('/admin')
+            and not is_public_read
+        )
 
-        if auto_authentication:
+        if should_auto_authenticate:
             self.auto_authenticate(request)
 
         print(f"User: {request.user}")

--- a/bible_research/middleware.py
+++ b/bible_research/middleware.py
@@ -10,13 +10,19 @@ class DeviceAndCountryMiddleware:
     and country information from Cloudflare headers or IP address.
     """
 
-    # Paths that must remain truly anonymous when no credentials are sent.
-    # Auto-authentication would silently create phantom users and hide the
-    # real DRF permission result for shared public-read endpoints.
-    PUBLIC_READ_PREFIXES = (
-        '/api/v1/bible',
+    # Paths that manage their own permissions via DRF and should never be
+    # auto-authenticated. Auto-authentication would silently create phantom
+    # users, hide DRF permission results on public reads, and let anonymous
+    # writes succeed under a device-derived username.
+    PERMISSION_MANAGED_PREFIXES = (
         '/api/v1/notes',
         '/api/v1/tags',
+    )
+
+    # Public read-only prefixes that don't need a user but also don't need
+    # DRF permission handling (bible content).
+    PUBLIC_READ_PREFIXES = (
+        '/api/v1/bible',
     )
 
     def __init__(self, get_response):
@@ -29,6 +35,9 @@ class DeviceAndCountryMiddleware:
 
         path = request.path
         method = request.method
+        is_permission_managed = any(
+            path.startswith(p) for p in self.PERMISSION_MANAGED_PREFIXES
+        )
         is_public_read = (
             method in ('GET', 'HEAD', 'OPTIONS')
             and any(path.startswith(p) for p in self.PUBLIC_READ_PREFIXES)
@@ -36,6 +45,7 @@ class DeviceAndCountryMiddleware:
         should_auto_authenticate = (
             not request.user.is_authenticated
             and not path.startswith('/admin')
+            and not is_permission_managed
             and not is_public_read
         )
 


### PR DESCRIPTION
## Summary
Implements the backend side of public note sharing tracked in #9 so
visitors who open a `/notes/tag/:id` or `/notes/:id` share link can see
every `public=True` note on that tag or the single public note — even
when they don't own it — while private notes stay hidden.

## What changed
- **Per-action permissions**
  - `NoteViewSet`: `list` / `retrieve` now `AllowAny`; all write actions
    still `IsAuthenticated`.
  - `TagViewSet`: `retrieve` is `AllowAny`; `list` and writes stay
    `IsAuthenticated`.
- **Middleware**
  - `DeviceAndCountryMiddleware` no longer auto-authenticates any
    request on `/api/v1/notes` or `/api/v1/tags` (previously it silently
    created a per-device user, which both polluted the user table and
    hid DRF's real permission branches).
- **`NoteViewSet.get_queryset` rewrite — explicit share semantics**
  - Anonymous: only `public=True` notes (further filtered by
    `tag_id` / `pk` if given).
  - Authenticated share view (`tag_id` or `pk` present) or
    `?public=true`: own notes ∪ all public notes, filtered.
  - Authenticated plain list: only own notes.
- **`TagViewSet.retrieve` is public** for any tag that has at least one
  public note (so share pages can resolve the tag name).
- **`NoteSerializer.is_owner`** — new read-only boolean derived from the
  request user, so clients can hide edit/delete controls on shared
  notes without exposing the owner's username.
- **Tests** — 10 new `APIClient`-driven tests in
  `annotations/tests.py::PublicNoteSharingTests` cover anonymous list
  by tag, retrieve public/private, authenticated mixing of own + public,
  the `is_owner` flag, write rejection, and the `TagViewSet` share rule.

## Verification against production DB (localhost:8000)
Confirmed every path with `curl`:

| Scenario | Expected | Got |
|---|---|---|
| Anon `GET /notes/?tag_id=<tag>` | only public notes | ✔ only public |
| Anon `GET /notes/<pub_id>` | 200 | 200 (`is_owner=false`) |
| Anon `GET /notes/<priv_id>` | 404 | 404 |
| Anon `GET /tags/<tag_with_public>` | 200 | 200 |
| Anon `POST /notes/` | 401 | 401 |
| Anon `PATCH /notes/<id>/` | 401 | 401 |
| Authed `GET /notes/<own_id>` | `is_owner=true` | true |

## Test plan
- [ ] `python manage.py test annotations.tests.PublicNoteSharingTests`
- [ ] Confirm existing tests still pass (the pre-existing
  `SerializerTestCase.test_note_serializer` failure is unrelated).
- [ ] Merge after the frontend counterpart
  (Bible-Research/reactive-bible) is reviewed.

Closes #9

Made with [Cursor](https://cursor.com)