### PR TITLE
feat: Display translation copyright at end of chapter

### DIFF
--- a/bible/services/dbt/client.py
+++ b/bible/services/dbt/client.py
@@ -283,12 +283,37 @@ class DBTClient:
         bible_id: str,
         **kwargs
     ) -> Dict[str, Any]:
-        """Get copyright info for a Bible."""
-        return self._make_request(
-            self.bibles_api.v4_bible_copyright,
-            bible_id,
-            **kwargs
-        )
+        """
+        Get copyright info for a Bible.
+
+        Uses requests directly instead of the generated
+        API client to avoid a deserialization bug
+        (missing Id model in openapi_client.models).
+
+        Args:
+            bible_id: Bible ID (e.g. 'ENGESV')
+            **kwargs: Additional query parameters
+
+        Returns:
+            List of fileset copyright objects
+        """
+        params = kwargs.copy()
+        params['v'] = 4
+        params['key'] = self.api_key
+
+        url = f"{self.base_url}/bibles/{bible_id}/copyright"
+
+        try:
+            response = self.session.get(
+                url, params=params
+            )
+            response.raise_for_status()
+            return response.json()
+        except requests.exceptions.RequestException as e:
+            logger.error(
+                f"DBT copyright request error: {e}"
+            )
+            raise
 
     def search(self, bible_id: str, query: str, **kwargs) -> Dict[str, Any]:
         """

--- a/bible/services/dbt/client.py
+++ b/bible/services/dbt/client.py
@@ -278,6 +278,18 @@ class DBTClient:
             logger.error(f"DBT timestamps request error: {e}")
             raise
 
+    def get_copyright(
+        self,
+        bible_id: str,
+        **kwargs
+    ) -> Dict[str, Any]:
+        """Get copyright info for a Bible."""
+        return self._make_request(
+            self.bibles_api.v4_bible_copyright,
+            bible_id,
+            **kwargs
+        )
+
     def search(self, bible_id: str, query: str, **kwargs) -> Dict[str, Any]:
         """
         Search for text in a specific Bible.

--- a/bible/tests/test_copyright_view.py
+++ b/bible/tests/test_copyright_view.py
@@ -1,0 +1,105 @@
+import pytest
+from unittest.mock import patch
+from rest_framework import status
+from rest_framework.test import APIRequestFactory
+
+from bible.views import CopyrightView
+
+
+@pytest.fixture
+def factory():
+    return APIRequestFactory()
+
+
+SAMPLE_COPYRIGHT_DATA = [
+    {
+        "id": "ENGESV",
+        "type": "text_plain",
+        "size": "C",
+        "copyright": {
+            "copyright_date": "2001",
+            "copyright": "© 2001 Crossway Bibles",
+            "copyright_description": (
+                "The Holy Bible, English Standard Version"
+            ),
+            "open_access": 0,
+        },
+    },
+    {
+        "id": "ENGESVN2DA",
+        "type": "audio",
+        "size": "NT",
+        "copyright": {
+            "copyright_date": "2001",
+            "copyright": "© 2001 Crossway Audio",
+            "copyright_description": "ESV Audio",
+            "open_access": 0,
+        },
+    },
+]
+
+
+@pytest.mark.django_db
+@patch('bible.views.get_default_dbt_client')
+def test_get_copyright_success(mock_get_client, factory):
+    """Test successful retrieval of copyright info."""
+    mock_dbt_instance = mock_get_client.return_value
+    mock_dbt_instance.get_copyright.return_value = (
+        SAMPLE_COPYRIGHT_DATA
+    )
+
+    request = factory.get(
+        '/fake-url/', {'bible_id': 'ENGESV'}
+    )
+    view = CopyrightView.as_view()
+    response = view(request)
+
+    assert response.status_code == status.HTTP_200_OK
+    assert len(response.data['data']) == 2
+
+    text_cr = response.data['data'][0]
+    assert text_cr['id'] == 'ENGESV'
+    assert text_cr['type'] == 'text_plain'
+    assert text_cr['copyright'] == (
+        '© 2001 Crossway Bibles'
+    )
+    assert text_cr['copyright_date'] == '2001'
+    assert text_cr['copyright_description'] == (
+        'The Holy Bible, English Standard Version'
+    )
+
+    mock_dbt_instance.get_copyright \
+        .assert_called_once_with('ENGESV')
+
+
+@pytest.mark.django_db
+def test_get_copyright_missing_bible_id(factory):
+    """Test request with missing bible_id parameter."""
+    request = factory.get('/fake-url/')
+    view = CopyrightView.as_view()
+    response = view(request)
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert 'error' in response.data
+
+
+@pytest.mark.django_db
+@patch('bible.views.get_default_dbt_client')
+def test_get_copyright_dbt_exception(
+    mock_get_client, factory
+):
+    """Test handling of an exception from DBT client."""
+    mock_dbt_instance = mock_get_client.return_value
+    mock_dbt_instance.get_copyright.side_effect = (
+        Exception("DBT Error")
+    )
+
+    request = factory.get(
+        '/fake-url/', {'bible_id': 'ENGESV'}
+    )
+    view = CopyrightView.as_view()
+    response = view(request)
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert 'error' in response.data
+    assert response.data['error'] == "DBT Error"

--- a/bible/tests/test_dbt_client.py
+++ b/bible/tests/test_dbt_client.py
@@ -63,17 +63,22 @@ def test_get_timestamps_injects_version(dbt_client):
 
 def test_get_copyright_calls_api(dbt_client):
     """
-    Test that get_copyright calls v4_bible_copyright
-    with correct args.
+    Test that get_copyright calls session.get with
+    the correct URL and parameters.
     """
-    dbt_client.bibles_api.v4_bible_copyright = Mock(
-        return_value=[{"id": "ENGESV", "copyright": {}}]
-    )
+    mock_response = Mock()
+    mock_response.json.return_value = [
+        {"id": "ENGESV", "copyright": {}}
+    ]
+    mock_response.raise_for_status = Mock()
+    dbt_client.session.get.return_value = mock_response
 
     result = dbt_client.get_copyright("ENGESV")
 
-    dbt_client.bibles_api.v4_bible_copyright \
-        .assert_called_once_with("ENGESV", v=4)
+    dbt_client.session.get.assert_called_once()
+    call_args, call_kwargs = dbt_client.session.get.call_args
+    assert 'ENGESV' in call_args[0]
+    assert call_kwargs.get('params', {}).get('v') == 4
     assert result == [
         {"id": "ENGESV", "copyright": {}}
     ]

--- a/bible/tests/test_dbt_client.py
+++ b/bible/tests/test_dbt_client.py
@@ -59,3 +59,21 @@ def test_get_timestamps_injects_version(dbt_client):
     call_args, call_kwargs = dbt_client.session.get.call_args
     params = call_kwargs.get('params', {})
     assert params.get('v') == 4
+
+
+def test_get_copyright_calls_api(dbt_client):
+    """
+    Test that get_copyright calls v4_bible_copyright
+    with correct args.
+    """
+    dbt_client.bibles_api.v4_bible_copyright = Mock(
+        return_value=[{"id": "ENGESV", "copyright": {}}]
+    )
+
+    result = dbt_client.get_copyright("ENGESV")
+
+    dbt_client.bibles_api.v4_bible_copyright \
+        .assert_called_once_with("ENGESV", v=4)
+    assert result == [
+        {"id": "ENGESV", "copyright": {}}
+    ]

--- a/bible/urls.py
+++ b/bible/urls.py
@@ -13,4 +13,9 @@ urlpatterns = [
         views.AudioTimestampView.as_view(),
         name='audio-timestamps'
     ),
+    path(
+        'bible/copyright/',
+        views.CopyrightView.as_view(),
+        name='bible-copyright'
+    ),
 ]

--- a/bible/views.py
+++ b/bible/views.py
@@ -189,6 +189,48 @@ class AudioTimestampView(APIView):
             )
 
 
+class CopyrightView(APIView):
+    """Return copyright info for a Bible translation."""
+
+    def get(self, request, format=None):
+        bible_id = request.query_params.get('bible_id')
+
+        if not bible_id:
+            return Response(
+                {"error": "bible_id is required."},
+                status=status.HTTP_400_BAD_REQUEST
+            )
+
+        try:
+            dbt_client = get_default_dbt_client()
+            result = dbt_client.get_copyright(bible_id)
+
+            filesets = []
+            for item in (result or []):
+                cr = item.get("copyright") or {}
+                filesets.append({
+                    "id": item.get("id"),
+                    "type": item.get("type"),
+                    "size": item.get("size"),
+                    "copyright": cr.get("copyright", ""),
+                    "copyright_date": cr.get(
+                        "copyright_date", ""
+                    ),
+                    "copyright_description": cr.get(
+                        "copyright_description", ""
+                    ),
+                })
+            return Response({"data": filesets})
+        except Exception as e:
+            logger.exception(
+                "Error fetching copyright: %s", e
+            )
+            return Response(
+                {"error": str(e)},
+                status=status.HTTP_400_BAD_REQUEST
+            )
+
+
 class TranslationListView(APIView):
     """
     Lists available Bible translations by fetching live from DBT API.


### PR DESCRIPTION
## Summary
Adds backend endpoint to fetch copyright info from DBT API and serve it to the frontend.

### Changes
- **DBTClient.get\_copyright()** — New method using direct `requests` call (bypasses generated client deserialization bug)
- **CopyrightView** — New DRF APIView at `/api/v1/bible/copyright/?bible_id=ENGESV`
- **URL route** — `bible/copyright/` added to urlpatterns
- **Tests** — 4 tests (1 client + 3 view)

### API Response
```json
{
  "data": [
    {
      "id": "ENGESV",
      "type": "text_plain",
      "size": "C",
      "copyright": "The ESV Bible® ...",
      "copyright_date": null,
      "copyright_description": ""
    }
  ]
}
```

### Note
Uses `requests.Session` directly instead of the generated OpenAPI client to avoid `AttributeError: module 'openapi_client.models' has no attribute 'Id'` — same pattern as `get_timestamps()`.