### PR TITLE
feat: inline images in CommentSerializer + prefetch N+1 fix

### DIFF
--- a/annotations/serializers.py
+++ b/annotations/serializers.py
@@ -261,67 +261,6 @@ class CommentAuthorSerializer(serializers.ModelSerializer):
         read_only_fields = ['id', 'username']
 
 
-class CommentSerializer(serializers.ModelSerializer):
-    """
-    Serializes a single Comment for both read and write operations.
-
-    - On write (POST/PATCH): accepts 'content' and optionally
-      'parent_comment' (its PK). 'user' and 'note' are injected
-      by the view.
-    - On read (GET): exposes author info via 'author' and omits
-      internal 'user' FK so clients receive a clean response.
-      The 'replies' field is populated by build_comment_tree and
-      is not part of the model schema.
-
-    N+1 prevention: this serializer is intentionally flat.
-    The view fetches all comments in one query and delegates
-    tree assembly to build_comment_tree().
-    """
-
-    author = CommentAuthorSerializer(
-        source='user',
-        read_only=True
-    )
-    parent_comment = serializers.PrimaryKeyRelatedField(
-        queryset=Comment.objects.all(),
-        allow_null=True,
-        required=False,
-        default=None
-    )
-
-    class Meta:
-        model = Comment
-        fields = [
-            'id',
-            'author',
-            'note_id',
-            'parent_comment',
-            'content',
-            'timestamp',
-            'is_deleted',
-        ]
-        read_only_fields = [
-            'id', 'author', 'note_id', 'timestamp',
-        ]
-
-    def validate_parent_comment(self, value):
-        """Ensure a reply targets a comment on the same note."""
-        if value is None:
-            return value
-        request = self.context.get('request')
-        note_pk = (
-            self.context.get('note_pk') or
-            (request and request.parser_context and
-             request.parser_context.get('kwargs', {})
-             .get('note_pk'))
-        )
-        if note_pk and str(value.note_id) != str(note_pk):
-            raise serializers.ValidationError(
-                "parent_comment must belong to the same note."
-            )
-        return value
-
-
 class ImageSerializer(serializers.ModelSerializer):
     """
     Read/write serializer for Image attachments.
@@ -367,6 +306,69 @@ class ImageSerializer(serializers.ModelSerializer):
             return None
 
 
+class CommentSerializer(serializers.ModelSerializer):
+    """
+    Serializes a single Comment for both read and write operations.
+
+    - On write (POST/PATCH): accepts 'content' and optionally
+      'parent_comment' (its PK). 'user' and 'note' are injected
+      by the view.
+    - On read (GET): exposes author info via 'author' and omits
+      internal 'user' FK so clients receive a clean response.
+      The 'replies' field is populated by build_comment_tree and
+      is not part of the model schema.
+
+    N+1 prevention: this serializer is intentionally flat.
+    The view fetches all comments in one query and delegates
+    tree assembly to build_comment_tree().
+    """
+
+    author = CommentAuthorSerializer(
+        source='user',
+        read_only=True
+    )
+    images = ImageSerializer(many=True, read_only=True)
+    parent_comment = serializers.PrimaryKeyRelatedField(
+        queryset=Comment.objects.all(),
+        allow_null=True,
+        required=False,
+        default=None
+    )
+
+    class Meta:
+        model = Comment
+        fields = [
+            'id',
+            'author',
+            'note_id',
+            'parent_comment',
+            'content',
+            'timestamp',
+            'is_deleted',
+            'images',
+        ]
+        read_only_fields = [
+            'id', 'author', 'note_id', 'timestamp', 'images',
+        ]
+
+    def validate_parent_comment(self, value):
+        """Ensure a reply targets a comment on the same note."""
+        if value is None:
+            return value
+        request = self.context.get('request')
+        note_pk = (
+            self.context.get('note_pk') or
+            (request and request.parser_context and
+             request.parser_context.get('kwargs', {})
+             .get('note_pk'))
+        )
+        if note_pk and str(value.note_id) != str(note_pk):
+            raise serializers.ValidationError(
+                "parent_comment must belong to the same note."
+            )
+        return value
+
+
 def build_comment_tree(queryset):
     """
     Assemble a flat Comment queryset into a nested tree structure.
@@ -388,6 +390,7 @@ def build_comment_tree(queryset):
         data = CommentSerializer(comment).data
         if comment.is_deleted:
             data['content'] = '[deleted]'
+            data['images'] = []
         data['replies'] = []
         comment_map[comment.id] = data
 

--- a/annotations/test_images.py
+++ b/annotations/test_images.py
@@ -7,7 +7,8 @@ import io
 from unittest.mock import MagicMock, patch
 
 from django.contrib.auth import get_user_model
-from django.db import IntegrityError, transaction
+from django.db import IntegrityError, connection, transaction
+from django.test.utils import CaptureQueriesContext
 from django.test import TestCase, override_settings
 from rest_framework.test import APIClient
 
@@ -512,3 +513,136 @@ class ImageDeleteAPITest(TestCase):
             Image.objects.filter(pk=self.image.id).exists()
         )
         mock_blob.delete.assert_called_once()
+
+
+class CommentInlineImagesTest(TestCase):
+    """Tests for images inlined in the comment tree response."""
+
+    def setUp(self):
+        self.user = User.objects.create_user(
+            username="inline_img_user",
+            email="inline_img@example.com",
+            password="pass",
+        )
+        self.note = Note.objects.create(
+            user=self.user,
+            note_text="Note for inline image tests",
+        )
+        self.client = APIClient()
+        self.client.force_authenticate(user=self.user)
+
+    def _comments_url(self):
+        return f"/api/v1/notes/{self.note.id}/comments/"
+
+    def _make_comment(self, content="Test comment", parent=None):
+        return Comment.objects.create(
+            user=self.user,
+            note=self.note,
+            content=content,
+            parent_comment=parent,
+        )
+
+    def _make_image(self, comment):
+        return Image.objects.create(
+            comment=comment,
+            uploaded_by=self.user,
+            storage_url=(
+                "gs://test-bucket/originals/x/source.png"
+            ),
+            content_type="image/png",
+            size_bytes=100,
+        )
+
+    @patch(
+        "annotations.services.image_storage.signed_image_url",
+        return_value="https://signed.example.com/img",
+    )
+    def test_inline_images_happy_path(self, _mock_sign):
+        """Comment with 2 images returns images array of length 2."""
+        comment = self._make_comment()
+        self._make_image(comment)
+        self._make_image(comment)
+        resp = self.client.get(self._comments_url())
+        self.assertEqual(resp.status_code, 200)
+        tree = resp.json()
+        self.assertEqual(len(tree), 1)
+        images = tree[0]["images"]
+        self.assertEqual(len(images), 2)
+        for key in (
+            "id", "signed_url", "content_type",
+            "size_bytes", "created_at",
+        ):
+            self.assertIn(key, images[0])
+
+    def test_empty_images_array_for_comment_without_attachments(
+        self,
+    ):
+        """Comment without attachments must have images: []."""
+        self._make_comment()
+        resp = self.client.get(self._comments_url())
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.json()[0]["images"], [])
+
+    @patch(
+        "annotations.services.image_storage.signed_image_url",
+        return_value="https://signed.example.com/img",
+    )
+    def test_nested_replies_have_own_images(self, _mock_sign):
+        """Replies include their own images arrays."""
+        root = self._make_comment("Root")
+        reply = self._make_comment("Reply", parent=root)
+        self._make_image(reply)
+        resp = self.client.get(self._comments_url())
+        self.assertEqual(resp.status_code, 200)
+        tree = resp.json()
+        self.assertEqual(tree[0]["images"], [])
+        self.assertEqual(
+            len(tree[0]["replies"][0]["images"]), 1
+        )
+
+    def test_soft_deleted_comment_returns_empty_images(self):
+        """Soft-deleted comment returns images: [] and [deleted]."""
+        comment = self._make_comment()
+        self._make_image(comment)
+        comment.is_deleted = True
+        comment.content = ""
+        comment.save(update_fields=["is_deleted", "content"])
+        resp = self.client.get(self._comments_url())
+        self.assertEqual(resp.status_code, 200)
+        node = resp.json()[0]
+        self.assertEqual(node["content"], "[deleted]")
+        self.assertEqual(node["images"], [])
+
+    def test_query_budget_does_not_grow_with_images(self):
+        """Exactly 1 comment query + 1 images prefetch query,
+        regardless of how many images are attached. Counted by
+        filtering captured SQL to business tables only so that
+        session/device-tracking middleware overhead is excluded.
+        """
+        comment = self._make_comment()
+        for _ in range(3):
+            self._make_image(comment)
+        with CaptureQueriesContext(connection) as ctx:
+            resp = self.client.get(self._comments_url())
+        self.assertEqual(resp.status_code, 200)
+        business = [
+            q for q in ctx.captured_queries
+            if '"annotations_comment"' in q['sql']
+            or '"annotations_image"' in q['sql']
+        ]
+        self.assertEqual(len(business), 2)
+
+    def test_write_path_ignores_images_key(self):
+        """POST with an 'images' key in payload is silently ignored;
+        the images field is read-only.
+        """
+        resp = self.client.post(
+            self._comments_url(),
+            {
+                "content": "Test",
+                "images": [{"id": "IMG_FAKE"}],
+            },
+            format="json",
+        )
+        self.assertEqual(resp.status_code, 201)
+        self.assertEqual(resp.json()["images"], [])

--- a/annotations/views.py
+++ b/annotations/views.py
@@ -398,6 +398,7 @@ class CommentViewSet(viewsets.ModelViewSet):
             Comment.objects
             .filter(note_id=note_pk)
             .select_related('user')
+            .prefetch_related('images')
             .order_by('timestamp')
         )
 


### PR DESCRIPTION
## Summary

Inline `images` directly in the comment tree response so the frontend
can render thumbnails without a per-comment round-trip fetch.

Closes the N+1 pattern described in `COMMENT_IMAGES_PLAN.md` §7.

---

## Changes

### `annotations/serializers.py`
- Moved `ImageSerializer` before `CommentSerializer` to eliminate the
  forward-reference.
- Added `images = ImageSerializer(many=True, read_only=True)` to
  `CommentSerializer`.
- Added `'images'` to `Meta.fields` and `Meta.read_only_fields`.
- `build_comment_tree`: blank `data['images'] = []` on soft-deleted
  nodes so the UI never shows orphan thumbnails next to `[deleted]`.

### `annotations/views.py`
- Added `.prefetch_related('images')` to `CommentViewSet.get_queryset`.
- Total DB cost: **2 queries** per list request (1 comments +
  select_related user, 1 images prefetch) regardless of thread size or
  image count.

### `annotations/test_images.py`
New `CommentInlineImagesTest` class — 6 cases:

| Test | What it checks |
|------|----------------|
| `test_inline_images_happy_path` | 2 images → `images` array len 2, expected keys present |
| `test_empty_images_array_for_comment_without_attachments` | No attachments → `images: []` (never null/missing) |
| `test_nested_replies_have_own_images` | Each reply carries its own `images` array |
| `test_soft_deleted_comment_returns_empty_images` | `images: []` + `content: '[deleted]'` on soft-deleted node |
| `test_query_budget_does_not_grow_with_images` | Business-query count locked at 2 via `CaptureQueriesContext` |
| `test_write_path_ignores_images_key` | `images` key in POST payload is silently ignored (read-only) |

---

## Non-goals / out of scope

- Inlining images on `NoteSerializer` (separate follow-up).
- Pagination of images per comment (cap is 5, unnecessary).
- Upload/delete endpoints unchanged.

## Rollout

Purely additive — new field on a read response, no DB migration,
no breaking change. Deploy backend first; frontend cleanup PR to follow
in `reactive-bible`.
