### PR TITLE
feat: bulk note creation under a single tag

### DIFF
--- a/annotations/serializers.py
+++ b/annotations/serializers.py
@@ -1,4 +1,5 @@
 from django.contrib.auth import get_user_model
+from django.db.models import Q
 from rest_framework import serializers
 from bible.models import Verse
 from bible.services.dbt.client import get_default_dbt_client
@@ -250,6 +251,161 @@ class NoteSerializer(serializers.ModelSerializer):
             representation['tag'] = TagSerializer(instance.tag).data
 
         return representation
+
+
+class BulkNoteItemSerializer(serializers.Serializer):
+    """Represents a single note in a bulk creation request."""
+    note_text = serializers.CharField(
+        required=False,
+        allow_blank=True,
+        default='',
+    )
+    public = serializers.BooleanField(
+        required=False,
+        default=False,
+    )
+    verse_references = NoteVerseReferenceSerializer(
+        many=True,
+        required=False,
+        default=list,
+    )
+
+
+class BulkNoteCreateSerializer(serializers.Serializer):
+    """
+    Serializer for bulk note creation under a single tag.
+    POST /api/v1/notes/bulk/
+    """
+    tag_id = serializers.PrimaryKeyRelatedField(
+        queryset=Tag.objects.all(),
+        help_text="UUID of the tag to assign to all notes.",
+    )
+    notes = BulkNoteItemSerializer(
+        many=True,
+        help_text="List of notes to create.",
+    )
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        request = self.context.get('request')
+        if request and hasattr(request, 'user'):
+            if request.user.is_authenticated:
+                self.fields['tag_id'].queryset = (
+                    Tag.objects.filter(user=request.user)
+                )
+            else:
+                try:
+                    guest_user = User.objects.get(
+                        username='guest'
+                    )
+                    self.fields['tag_id'].queryset = (
+                        Tag.objects.filter(user=guest_user)
+                    )
+                except User.DoesNotExist:
+                    self.fields['tag_id'].queryset = (
+                        Tag.objects.none()
+                    )
+
+    def validate_notes(self, value):
+        if not value:
+            raise serializers.ValidationError(
+                "At least one note is required."
+            )
+        return value
+
+    def _resolve_verses(self, notes_data):
+        """
+        Batch-fetches all Verse instances referenced across
+        all notes. Returns a dict keyed by
+        (book_lower, chapter, verse).
+        Raises ValidationError for any verse not found.
+        """
+        unique_keys = set()
+        for note_data in notes_data:
+            for ref in note_data.get('verse_references', []):
+                unique_keys.add((
+                    ref['book'].lower(),
+                    ref['chapter'],
+                    ref['verse'],
+                ))
+        if not unique_keys:
+            return {}
+
+        query = Q()
+        for book, chapter, verse in unique_keys:
+            query |= Q(
+                book__iexact=book,
+                chapter=chapter,
+                verse=verse,
+            )
+        fetched = Verse.objects.filter(query)
+        verse_map = {
+            (v.book.lower(), v.chapter, v.verse): v
+            for v in fetched
+        }
+        missing = unique_keys - set(verse_map.keys())
+        if missing:
+            missing_str = ', '.join(
+                f"{b} {c}:{v}"
+                for b, c, v in sorted(missing)
+            )
+            raise serializers.ValidationError(
+                f"Verses not found: {missing_str}. "
+                "Please ensure the verses exist "
+                "in your database."
+            )
+        return verse_map
+
+    def create(self, validated_data):
+        """
+        Bulk-creates all notes and their verse links.
+        Called inside transaction.atomic() by the view.
+        """
+        tag = validated_data['tag_id']
+        notes_data = validated_data['notes']
+        request = self.context.get('request')
+
+        if request and request.user.is_authenticated:
+            user = request.user
+        else:
+            try:
+                user = User.objects.get(username='guest')
+            except User.DoesNotExist:
+                user = None
+
+        verse_map = self._resolve_verses(notes_data)
+
+        note_instances = [
+            Note(
+                note_text=nd.get('note_text', ''),
+                public=nd.get('public', False),
+                tag=tag,
+                user=user,
+            )
+            for nd in notes_data
+        ]
+        Note.objects.bulk_create(note_instances)
+
+        nv_instances = []
+        for note_obj, nd in zip(
+            note_instances, notes_data
+        ):
+            for ref in nd.get('verse_references', []):
+                key = (
+                    ref['book'].lower(),
+                    ref['chapter'],
+                    ref['verse'],
+                )
+                nv_instances.append(
+                    NoteVerse(
+                        note=note_obj,
+                        verse=verse_map[key],
+                    )
+                )
+        if nv_instances:
+            NoteVerse.objects.bulk_create(nv_instances)
+
+        return note_instances
 
 
 class CommentAuthorSerializer(serializers.ModelSerializer):

--- a/annotations/tests.py
+++ b/annotations/tests.py
@@ -8,7 +8,7 @@ from annotations.serializers import (
     NoteSerializer,
     build_comment_tree,
 )
-from annotations.models import Comment, Note
+from annotations.models import Comment, Note, Tag
 from bible.models import Verse
 
 
@@ -652,3 +652,142 @@ class CommentCountViewTest(TestCase):
                 self.URL, {'tag_id': self.tag.id}
             )
         self.assertEqual(resp.status_code, 200)
+
+
+class BulkNoteCreateTest(TestCase):
+    """Integration tests for POST /api/v1/notes/bulk/."""
+
+    URL = '/api/v1/notes/bulk/'
+
+    def setUp(self):
+        User = get_user_model()
+        self.user = User.objects.create_user(
+            username='bulk_user',
+            email='bulk@example.com',
+            password='pass',
+        )
+        self.tag = Tag.objects.create(
+            user=self.user,
+            name='BulkTag',
+        )
+        self.verse, _ = Verse.objects.get_or_create(
+            book='John',
+            chapter=3,
+            verse=16,
+        )
+        self.client = APIClient()
+        self.client.force_authenticate(user=self.user)
+
+    def test_bulk_create_happy_path(self):
+        """POST creates all notes and returns 201."""
+        payload = {
+            'tag_id': self.tag.id,
+            'notes': [
+                {
+                    'note_text': 'First note',
+                    'public': False,
+                    'verse_references': [],
+                },
+                {
+                    'note_text': 'Second note',
+                    'public': True,
+                    'verse_references': [],
+                },
+            ],
+        }
+        resp = self.client.post(
+            self.URL, payload, format='json'
+        )
+        self.assertEqual(resp.status_code, 201)
+        data = resp.json()
+        self.assertEqual(len(data), 2)
+        texts = [n['note_text'] for n in data]
+        self.assertIn('First note', texts)
+        self.assertIn('Second note', texts)
+        self.assertEqual(
+            Note.objects.filter(tag=self.tag).count(), 2
+        )
+
+    def test_bulk_create_missing_verse_returns_400(self):
+        """A non-existent verse reference returns 400."""
+        payload = {
+            'tag_id': self.tag.id,
+            'notes': [
+                {
+                    'note_text': 'Bad verse note',
+                    'verse_references': [
+                        {
+                            'book': 'John',
+                            'chapter': 99,
+                            'verse': 99,
+                        }
+                    ],
+                }
+            ],
+        }
+        resp = self.client.post(
+            self.URL, payload, format='json'
+        )
+        self.assertEqual(resp.status_code, 400)
+        self.assertEqual(
+            Note.objects.filter(tag=self.tag).count(), 0
+        )
+
+    def test_bulk_create_wrong_tag_returns_400(self):
+        """A tag_id belonging to another user returns 400."""
+        User = get_user_model()
+        other_user = User.objects.create_user(
+            username='bulk_other',
+            email='bulk_other@example.com',
+            password='pass',
+        )
+        other_tag = Tag.objects.create(
+            user=other_user,
+            name='OtherBulkTag',
+        )
+        payload = {
+            'tag_id': other_tag.id,
+            'notes': [{'note_text': 'Attempt'}],
+        }
+        resp = self.client.post(
+            self.URL, payload, format='json'
+        )
+        self.assertEqual(resp.status_code, 400)
+
+    def test_bulk_create_empty_notes_returns_400(self):
+        """An empty notes list returns 400."""
+        payload = {
+            'tag_id': self.tag.id,
+            'notes': [],
+        }
+        resp = self.client.post(
+            self.URL, payload, format='json'
+        )
+        self.assertEqual(resp.status_code, 400)
+
+    def test_bulk_create_atomicity(self):
+        """A bad verse in one note prevents all notes from
+        being created (atomicity check)."""
+        payload = {
+            'tag_id': self.tag.id,
+            'notes': [
+                {'note_text': 'Good note', 'verse_references': []},
+                {
+                    'note_text': 'Bad note',
+                    'verse_references': [
+                        {
+                            'book': 'John',
+                            'chapter': 99,
+                            'verse': 99,
+                        }
+                    ],
+                },
+            ],
+        }
+        resp = self.client.post(
+            self.URL, payload, format='json'
+        )
+        self.assertEqual(resp.status_code, 400)
+        self.assertEqual(
+            Note.objects.filter(tag=self.tag).count(), 0
+        )

--- a/annotations/views.py
+++ b/annotations/views.py
@@ -1,6 +1,7 @@
 import logging
 
 from drf_spectacular.utils import extend_schema, OpenApiParameter
+from rest_framework.decorators import action
 from drf_spectacular.types import OpenApiTypes
 from rest_framework import viewsets, status as drf_status
 from rest_framework.exceptions import PermissionDenied, ValidationError
@@ -18,6 +19,7 @@ from .models import Tag, Note, Comment, Image, generate_image_id
 from .serializers import (
     TagSerializer,
     NoteSerializer,
+    BulkNoteCreateSerializer,
     CommentSerializer,
     ImageSerializer,
     build_comment_tree,
@@ -342,6 +344,31 @@ class NoteViewSet(viewsets.ModelViewSet):
             f"Returning {final_queryset.count()} notes"
         )
         return final_queryset
+
+    @action(
+        detail=False, methods=['post'], url_path='bulk'
+    )
+    def bulk_create_notes(self, request):
+        """
+        Bulk-create notes under a single tag.
+        POST /api/v1/notes/bulk/
+        """
+        serializer = BulkNoteCreateSerializer(
+            data=request.data,
+            context=self.get_serializer_context(),
+        )
+        serializer.is_valid(raise_exception=True)
+        with transaction.atomic():
+            notes = serializer.save()
+        output = NoteSerializer(
+            notes,
+            many=True,
+            context=self.get_serializer_context(),
+        )
+        return Response(
+            output.data,
+            status=drf_status.HTTP_201_CREATED,
+        )
 
 
 class CommentViewSet(viewsets.ModelViewSet):


### PR DESCRIPTION
## Summary
Adds a new endpoint for creating multiple notes under a single tag in one atomic request.

## Endpoint
```
POST /api/v1/notes/bulk/
```

## Request Body
```json
{
  "tag_id": "<tag-uuid>",
  "notes": [
    {
      "note_text": "...",
      "public": false,
      "verse_references": [
        {"book": "John", "chapter": 3, "verse": 16}
      ]
    },
    {"note_text": "...", "public": true, "verse_references": []}
  ]
}
```

## Changes
- **serializers.py**: `BulkNoteItemSerializer` (single note item) and `BulkNoteCreateSerializer` (top-level); batch verse lookup in one query; `bulk_create` for notes and NoteVerse links
- **views.py**: `@action` on `NoteViewSet` at `url_path='bulk'`; wrapped in `transaction.atomic()`
- **tests.py**: 5 integration tests covering happy path, missing verse (400), wrong tag_id (400), empty list (400), and atomicity rollback

## Design Decisions
- `tag_id` is top-level (all notes share one tag, per requirements)
- `tag_id` queryset is scoped to the requesting user's tags (same pattern as `NoteSerializer`)
- Verse lookup is batched — avoids N+1 queries vs. the single-note path
- `transaction.atomic()` in the view ensures all-or-nothing creation
