### PR TITLE
Feat: Add audio support for ESV_API via passage/audio endpoint

### DIFF
--- a/bible/serializers.py
+++ b/bible/serializers.py
@@ -52,10 +52,17 @@ class BiblePassageSerializer(serializers.Serializer):
         try:
             if is_esv_fileset(fileset_id):
                 if response_format == 'audio':
-                    raise ValueError(
-                        "ESV API fileset does not provide audio. "
-                        "Use ENGESV (DBT) or ENGESHN1DA for audio."
+                    audio_url = (
+                        get_default_esv_client()
+                        .get_chapter_audio_url(book_id, chapter)
                     )
+                    return {
+                        'book': book_id,
+                        'book_name': book_name,
+                        'chapter': chapter,
+                        'format': 'audio',
+                        'audio_url': audio_url,
+                    }
                 parsed = (
                     get_default_esv_client()
                     .get_chapter_with_headings(book_id, chapter)

--- a/bible/services/esv/client.py
+++ b/bible/services/esv/client.py
@@ -12,6 +12,7 @@ from bible.utils.bible_books import get_book_name_from_id
 logger = logging.getLogger(__name__)
 
 ESV_BASE_URL = "https://api.esv.org/v3/passage/text/"
+ESV_AUDIO_BASE_URL = "https://api.esv.org/v3/passage/audio/"
 
 _VERSE_MARKER = re.compile(r"\[(\d+)\]")
 
@@ -57,6 +58,48 @@ class ESVClient:
         raw = self.fetch_chapter_raw(book_id, chapter)
         passage = (raw.get("passages") or [""])[0]
         return _parse_passage(passage)["verses"]
+
+    def get_chapter_audio_url(
+        self, book_id: str, chapter: int
+    ) -> str:
+        """Return the CDN redirect URL for a chapter MP3.
+
+        The ESV audio endpoint responds with a 3xx redirect to
+        the actual MP3 on their CDN.  We capture the Location
+        header and return it so the frontend can play directly.
+
+        Args:
+            book_id: Standard book ID (e.g. 'GEN', 'JHN').
+            chapter: Chapter number.
+
+        Returns:
+            Absolute URL string pointing to the chapter MP3.
+
+        Raises:
+            ValueError: If the API does not redirect as expected.
+            requests.HTTPError: On 4xx/5xx from the ESV API.
+        """
+        book_name = get_book_name_from_id(book_id)
+        params = {"q": f"{book_name} {chapter}"}
+        r = self.session.get(
+            ESV_AUDIO_BASE_URL,
+            params=params,
+            allow_redirects=False,
+            timeout=10,
+        )
+        if r.status_code not in (301, 302, 303, 307, 308):
+            r.raise_for_status()
+            raise ValueError(
+                "Expected redirect from ESV audio API, "
+                f"got HTTP {r.status_code}"
+            )
+        location = r.headers.get("Location")
+        if not location:
+            raise ValueError(
+                "ESV audio API redirect contained no "
+                f"Location header for {book_name} {chapter}"
+            )
+        return location
 
     def get_chapter_with_headings(
         self, book_id: str, chapter: int

--- a/bible/services/esv/registry.py
+++ b/bible/services/esv/registry.py
@@ -35,6 +35,11 @@ def get_esv_translation_listing() -> list:
                     "type": "text_plain",
                     "size": "C",
                 },
+                {
+                    "id": fid,
+                    "type": "audio",
+                    "size": "C",
+                },
             ],
         }
         for fid, meta in ESV_TRANSLATIONS.items()

--- a/bible/tests/test_esv_client.py
+++ b/bible/tests/test_esv_client.py
@@ -7,6 +7,7 @@ from rest_framework.test import APIClient
 
 from bible.services.esv.client import (
     ESVClient,
+    ESV_AUDIO_BASE_URL,
     _parse_passage,
 )
 from bible.services.esv.registry import (
@@ -54,9 +55,13 @@ class ESVRegistryTests(TestCase):
         self.assertEqual(entry["abbr"], "ESV")
         self.assertEqual(entry["iso"], "eng")
         filesets = entry["filesets"]
-        self.assertEqual(len(filesets), 1)
-        self.assertEqual(filesets[0]["id"], "ENGESV_API")
-        self.assertEqual(filesets[0]["type"], "text_plain")
+        self.assertEqual(len(filesets), 2)
+        types = {f["type"] for f in filesets}
+        self.assertIn("text_plain", types)
+        self.assertIn("audio", types)
+        for f in filesets:
+            self.assertEqual(f["id"], "ENGESV_API")
+            self.assertEqual(f["size"], "C")
 
 
 # ============================================================
@@ -161,7 +166,18 @@ class ESVSerializerRoutingTests(TestCase):
         )
 
     @override_settings(ESV_KEY="test-key")
-    def test_serializer_rejects_esv_audio(self):
+    @patch(
+        "bible.serializers.get_default_esv_client"
+    )
+    def test_serializer_returns_esv_audio_url(
+        self, mock_get
+    ):
+        mock_client = MagicMock()
+        mock_client.get_chapter_audio_url.return_value = (
+            "https://cdn.esv.org/audio/genesis_1.mp3"
+        )
+        mock_get.return_value = mock_client
+
         data = {
             "book": "GEN",
             "book_name": "Genesis",
@@ -172,8 +188,71 @@ class ESVSerializerRoutingTests(TestCase):
         result = BiblePassageSerializer(data).to_representation(
             data
         )
-        self.assertEqual(result.get("verses", []), [])
-        self.assertIn("message", result)
+        self.assertEqual(result["format"], "audio")
+        self.assertEqual(
+            result["audio_url"],
+            "https://cdn.esv.org/audio/genesis_1.mp3",
+        )
+        mock_client.get_chapter_audio_url.assert_called_once_with(
+            "GEN", 1
+        )
+
+
+# ============================================================
+# get_chapter_audio_url — redirect handling
+# ============================================================
+
+class ESVClientAudioTests(TestCase):
+    @override_settings(ESV_KEY="test-key")
+    def test_returns_location_from_redirect(self):
+        client = ESVClient(api_key="test-key")
+        mock_resp = MagicMock()
+        mock_resp.status_code = 302
+        mock_resp.headers = {
+            "Location": "https://cdn.esv.org/audio/jhn_3.mp3"
+        }
+        client.session.get = MagicMock(
+            return_value=mock_resp
+        )
+
+        url = client.get_chapter_audio_url("JHN", 3)
+
+        self.assertEqual(
+            url, "https://cdn.esv.org/audio/jhn_3.mp3"
+        )
+        call_args, call_kwargs = client.session.get.call_args
+        self.assertIn(ESV_AUDIO_BASE_URL, call_args)
+        params = call_kwargs.get("params", {})
+        self.assertIn("John 3", params.get("q", ""))
+        self.assertFalse(
+            call_kwargs.get("allow_redirects", True)
+        )
+
+    @override_settings(ESV_KEY="test-key")
+    def test_raises_if_no_location_header(self):
+        client = ESVClient(api_key="test-key")
+        mock_resp = MagicMock()
+        mock_resp.status_code = 302
+        mock_resp.headers = {}
+        client.session.get = MagicMock(
+            return_value=mock_resp
+        )
+
+        with self.assertRaises(ValueError):
+            client.get_chapter_audio_url("GEN", 1)
+
+    @override_settings(ESV_KEY="test-key")
+    def test_raises_on_non_redirect_status(self):
+        client = ESVClient(api_key="test-key")
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.raise_for_status = MagicMock()
+        client.session.get = MagicMock(
+            return_value=mock_resp
+        )
+
+        with self.assertRaises(ValueError):
+            client.get_chapter_audio_url("GEN", 1)
 
 
 # ============================================================


### PR DESCRIPTION
## Summary

Implements audio playback support for the `ENGESV_API` fileset using the [ESV API passage/audio endpoint](https://api.esv.org/docs/passage-audio/).

Previously, requesting `response_format=audio` with `fileset_id=ENGESV_API` raised a `ValueError` and returned an error response. Now it returns a valid `audio_url` pointing to the ESV CDN MP3.

## Changes

### `bible/services/esv/client.py`
- Added `ESV_AUDIO_BASE_URL = "https://api.esv.org/v3/passage/audio/"`
- Added `ESVClient.get_chapter_audio_url(book_id, chapter)` — calls the ESV audio endpoint with `allow_redirects=False`, captures the `Location` header from the 3xx redirect, and returns the CDN MP3 URL

### `bible/services/esv/registry.py`
- Added a second fileset entry `{"id": "ENGESV_API", "type": "audio", "size": "C"}` to `get_esv_translation_listing()` so the frontend `TranslationSelector` surfaces `ENGESV_API` as a selectable audio option

### `bible/serializers.py`
- Replaced the `raise ValueError` for ESV audio with a call to `get_chapter_audio_url()` and a proper `{"format": "audio", "audio_url": "..."}` response

### `bible/tests/test_esv_client.py`
- Updated `test_translation_listing_shape` to expect 2 filesets (text + audio)
- Replaced `test_serializer_rejects_esv_audio` with `test_serializer_returns_esv_audio_url`
- Added `ESVClientAudioTests` with 3 new tests: happy-path redirect, missing `Location` header, non-redirect status code

## How it works

The ESV audio endpoint (`GET /v3/passage/audio/?q=John+3`) responds with a `302` redirect to an MP3 on the ESV CDN. The backend captures the `Location` header (without downloading the file) and returns it as `audio_url`. The frontend's existing `getBibleAudioUrl` → Howler.js flow plays it without any frontend changes.

## Test results

```
Ran 20 tests in 0.100s
OK
```
